### PR TITLE
support multiple mime-types in the Accept header, and honor q= values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,11 +138,11 @@ where
 
             _ => {
                 tracing::error!("unsupported accept header: {:?}", accept);
-                return Err((
+                Err((
                     StatusCode::NOT_ACCEPTABLE,
                     "Invalid content type on request",
                 )
-                    .into_response());
+                    .into_response())
             }
         }
     }


### PR DESCRIPTION
Allow multiple mime types in the `Accept` header, and honor requested `q=` values.  